### PR TITLE
Fix fetch flags URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function patchFlag(patch, key, cb) {
 
 var fetchFlags = function (cb) {
   var options = {
-    url: baseUrl + '/flags/' + projectKey,
+    url: `${baseUrl}/flags/${projectKey}?summary=0&env=${sourceEnvironment}&env=${destinationEnvironment}`,
     headers: {
       'Authorization': apiToken,
       'Content-Type': 'application/json'


### PR DESCRIPTION
Recent breaking change to API that returns the summary reps by default.  Also limited the fetched configs to the source and destination envs to speed things up.